### PR TITLE
Removed test_make_geopackage

### DIFF
--- a/tests/test_prep_data_for_processing.py
+++ b/tests/test_prep_data_for_processing.py
@@ -80,23 +80,25 @@ def test_get_points(la_ids, expect_no_pts):
 #     assert isinstance(grid_125m, gpd.GeoDataFrame)
 #     assert isinstance(grid_1km, gpd.GeoDataFrame)
 
-
-def test_make_geopackage():
-    gridgran.make_points_geopackage(
-        GPKG,
-        ['Woking'],
-        'LAD21NM',
-        GPKG,
-        GPKG,
-        GPKG,
-        GRIDS_125m,
-        out_layer='points',
-        la_layer=LA_LAYER,
-        pt_layer=PT_LAYER,
-        pt_pop_col='people',
-        layer_1km='GLOBAL_1km',
-        layer_125m=None
-    )
-    assert 'points' in fiona.listlayers(GPKG)
-    assert '1000m' in fiona.listlayers(GPKG)
-    assert '125m' in fiona.listlayers(GPKG)
+# This test is commented out because it can't be run on github (needs
+# network connection). It can be reinstated but check the path to GRIDS_125m
+# relative to the tester's computer
+# def test_make_geopackage():
+#     gridgran.make_points_geopackage(
+#         GPKG,
+#         ['Woking'],
+#         'LAD21NM',
+#         GPKG,
+#         GPKG,
+#         GPKG,
+#         GRIDS_125m,
+#         out_layer='points',
+#         la_layer=LA_LAYER,
+#         pt_layer=PT_LAYER,
+#         pt_pop_col='people',
+#         layer_1km='GLOBAL_1km',
+#         layer_125m=None
+#     )
+#     assert 'points' in fiona.listlayers(GPKG)
+#     assert '1000m' in fiona.listlayers(GPKG)
+#     assert '125m' in fiona.listlayers(GPKG)


### PR DESCRIPTION
Removed test_make_geopackage in test_prep_data_for_processing because it is pointing to a network file and cannot be tested on github